### PR TITLE
Sort input file list

### DIFF
--- a/Python/configure.py
+++ b/Python/configure.py
@@ -1584,7 +1584,7 @@ macx {
     pro.write('HEADERS = sipAPI%s.h\n' % mname)
 
     pro.write('SOURCES =')
-    for s in os.listdir(module_config.name):
+    for s in sorted(os.listdir(module_config.name)):
         if s.endswith('.cpp'):
             pro.write(' \\\n    %s' % s)
     pro.write('\n')


### PR DESCRIPTION
Sort input file list
so that Qsci.so builds in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

Without this patch, openSUSE's python-qscintilla-qt5 package
varied for every build.

Also [sent this upstream](https://www.riverbankcomputing.com/pipermail/qscintilla/2018-November/001349.html), but could not find a git repo